### PR TITLE
zola: bump runtime from 23.08 to 24.08

### DIFF
--- a/org.getzola.zola.yml
+++ b/org.getzola.zola.yml
@@ -1,6 +1,6 @@
 app-id: org.getzola.zola
 runtime: org.freedesktop.Platform
-runtime-version: '23.08'
+runtime-version: '24.08'
 sdk: org.freedesktop.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.rust-stable


### PR DESCRIPTION
Hi, 

this is a tiny PR bumping the freedesktop runtime to 24.08.

Builds fine on aarch64, did not test x86_86.


